### PR TITLE
bugfix：各パターンのスタイルバグを修正

### DIFF
--- a/block-styles/snow-monkey-blocks/section-with-bgimage/RJE_R002LP_hero_one_column/_common.scss
+++ b/block-styles/snow-monkey-blocks/section-with-bgimage/RJE_R002LP_hero_one_column/_common.scss
@@ -17,37 +17,64 @@
 		margin-bottom: 6.25em;
 	}
 	//セクション背景
-	.smb-section-with-bgimage__bgimage{
+	> .smb-section-with-bgimage__bgimage{
 		max-width: calc(100% - 2em);
-		margin-right: 1em;
-		margin-left: 1em;
+		margin-right: auto;
+		margin-left: auto;
 		@include mq(sm){
 			max-width: (100% - 8.32%);
-			margin-right: auto;
-			margin-left: auto;
+		}
+		@include mq(lg){
+			max-width: 100%;
 		}
 	}
 	//セクションの内包
-	.c-container{
+	> .c-container{
+		max-width: calc(100% - 2em);
+		margin-right: auto;
+		margin-left: auto;
 		padding-right: 1em;
 		padding-left: 1em;
-	}
-	//セクションタイトル
-	.smb-section__title{
-		@include heading1;
-		&::after{
-			display: none;
+		@include mq(sm){
+			max-width: (100% - 8.32%);
 		}
-		
-	}
-	//セクションボディ
-	.smb-section__body{
-		margin-top: 1.5em;
-		:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6)+:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6){
-			margin-top: 1em;
+		@include mq(lg){
+			max-width: 100%;
 		}
-		.smb-buttons{
-			margin-top: 4em;
+		//セクションタイトル
+		> .smb-section__title{
+			@include heading1;
+			&::after{
+				display: none;
+			}
+		}
+		//セクションボディ
+		> .smb-section__body{
+			margin-top: 1.5em;
+			:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6)+:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6){
+				margin-top: 1em;
+			}
+			.smb-buttons{
+				margin-top: 4em;
+			}
+		}
+	}
+
+	//サイドバーありのテンプレート以外 かつ セクション自体俄然幅表示
+	body:not(.page-template-left-sidebar):not(.page-template-right-sidebar) &{
+		&.alignfull{
+			//セクション背景
+			> .smb-section-with-bgimage__bgimage{
+				@include mq(lg){
+					max-width: (100% - 8.32%);
+				}
+			}
+			//内包コンテナ
+			> .c-container{
+				@include mq(lg){
+					max-width: (100% - 8.32%);
+				}
+			}
 		}
 	}
 }

--- a/block-styles/snow-monkey-blocks/section/RJE_R002LP_message_accent2/_common.scss
+++ b/block-styles/snow-monkey-blocks/section/RJE_R002LP_message_accent2/_common.scss
@@ -10,15 +10,9 @@
 .is-style-RJE_R002LP_message_accent2{
 	position: relative;
 	padding: 0.625rem;
-	@include mq(md){
-		padding: 1.25rem;
-	}
-	.smb-section__inner{
+	> .smb-section__inner{
 		padding: 2.375rem 1.125rem;
 		border: 1px solid #8F8F8F;
-		@include mq(md){
-			padding: 3.75rem 3.75rem 4.75rem;
-		}
 		> .c-container{
 			> .smb-section__subtitle{
 				margin-bottom: 1.25rem;
@@ -50,4 +44,17 @@
 			}
 		}
 	}
+	//スリム幅・サイド幅以外
+	body:not(.page-template-left-sidebar):not(.page-template-right-sidebar):not(.page-template-blank-slim):not(.page-template-one-column-slim) &{
+		@include mq(md){
+			padding: 1.25rem;
+		}
+		> .smb-section__inner{
+			@include mq(md){
+				padding: 3.75rem 3.75rem 4.75rem;
+			}
+		}
+	}
 }
+
+


### PR DESCRIPTION
Hero1カラム：フル幅のレイアウトのときに、SP幅〜PC幅まで左右の余白がない #31
Hero1カラム：サイドバーありの場合マージンをなくす #33
伝えたいこと：サイドバーあり・スリム幅のときにはPC時もタブレットのスタイルを適応する #37